### PR TITLE
fix: Correct form alignment for fieldsets

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,12 +44,15 @@
   }
   fieldset {
     border: none;
-    padding: 0;
     margin: 0;
+    padding: 0;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
+    padding-inline-start: 0;
+    padding-inline-end: 0;
+    margin-top: 15px;
   }
   legend {
-    display: block;
-    margin-top: 15px;
     font-weight: bold;
     padding: 0;
     margin-bottom: 5px;


### PR DESCRIPTION
This commit fixes a styling issue where radio button groups with long labels were misaligned with other form elements.

The issue was caused by inconsistent default browser styling of the `<fieldset>` element.

This has been resolved by applying a more robust CSS reset to the `fieldset` element, using specific properties like `margin-inline-start` and `padding-inline-start` to ensure a consistent and clean layout across different browsers.